### PR TITLE
v3.7.3 Fix for "little boxes"

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 
-const APP_VERSION = '3.7.2';
+const APP_VERSION = '3.7.3';
 const LOCALSTORE_BASE_NAME = 'OPENMCT_SCRIPTING';
 const ESC_CHARS = {
     'comma': '$C',

--- a/main-csv-to-matrix.js
+++ b/main-csv-to-matrix.js
@@ -216,9 +216,9 @@ function createOpenMCTMatrixLayoutJSONfromCSV(csv) {
                         dlMatrix.configuration.objectStyles[dlItem.id].styles = telemetryObject.alphaObjStyles;
                         dlMatrix.configuration.objectStyles[dlItem.id].conditionSetIdentifier = telemetryObject.csKey;
                     }
-                }
 
-                dlMatrix.addToComposition(cell, getNamespace(cell));
+                    dlMatrix.addToComposition(cell, getNamespace(cell));
+                }
             } else if (cell.length > 0) {
                 // Add as a text object
                 const args = {


### PR DESCRIPTION
Was erroneously adding telem paths to the matrix layout's composition when designated as a Condition Widget. This had the effect of adding an alphanumeric for every CW, but without position or size properties, resulting in "little boxes". Code fixed to now only add a telem path to the layout's composition if it's intended to be an alphanumeric.