### PR TITLE
Fix #34

### DIFF
--- a/DisplayLayouts.js
+++ b/DisplayLayouts.js
@@ -29,9 +29,7 @@ const DisplayLayout = function (args) {
             'y': 0,
             'width': parseInt(args.itemW),
             'height': parseInt(args.itemH),
-            "stroke": '',
-            "fill": '',
-            "color": '',
+            "stroke": 'transparent',
             'fontSize': 'default',
             'font': 'default'
         };

--- a/DomainObjects.js
+++ b/DomainObjects.js
@@ -32,16 +32,16 @@ const Obj = function (name, type, hasComposition) {
 function createStyleObj(args) {
     let obj = {};
     obj.style = {};
-    obj.style.output = (args && args.output) ? args.output : '';
-    obj.style.border = (args && args.border) ? args.border : '';
-    obj.style.imageUrl = (args && args.url) ? args.url : '';
-    // Yes, this is really how it was done.
-    obj.style.isStyleInvisible = (args && args.isStyleInvisible) ? 'is-style-invisible' : '';
-    obj.style.backgroundColor = (args && args.bgColor) ? args.bgColor : '';
-    obj.style.color = (args && args.fgColor) ? args.fgColor : '';
-    if (args && args.id) {
-        // Used within a styles array for conditional styling
-        obj.conditionId = args.id;
+
+    if (args) {
+        obj.style.output = args.output ? args.output : '';
+        obj.style.isStyleInvisible = args.isStyleInvisible ? args.isStyleInvisible : '';
+        if (args.output) { obj.style.output = args.output; }
+        if (args.border) { obj.style.border = args.border; }
+        if (args.url) { obj.style.imageUrl = args.url; }
+        if (args.bgColor) { obj.style.backgroundColor = args.bgColor; }
+        if (args.fgColor) { obj.style.color = args.fgColor; }
+        if (args.id) { obj.conditionId = args.id; }
     }
 
     return obj;

--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 
-const APP_VERSION = '3.11';
+const APP_VERSION = '3.12';
 const LOCALSTORE_BASE_NAME = 'OPENMCT_SCRIPTING';
 const ESC_CHARS = {
     'comma': '$C',


### PR DESCRIPTION
- Set Display Layout sub-objects to use "stroke": "transparent" by default.
- Remove blank Display Layout sub-objects "fill" and "color" properties.
- Refactor `createStyleObj` to only add certain properties to `obj.style` when values are provided.
`.output` and `.isStyleInvisible` are still being set to "" as that mimics output in manually created DL's.